### PR TITLE
Version management improvements and dependency cleanup

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -750,6 +750,10 @@ echo "  2. Edit the draft release"
 echo "  3. Click '\''Publish release'\''"
 '''
 
+[tasks.testbump]
+description = "Bump version in pyproject.toml and test assertions. Usage: mise run testbump [patch|minor]"
+run = "python scripts/bump_version.py"
+
 # Help task
 [tasks.help]
 description = "Show available tasks organized by category"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Bump the package version and sync test assertions."""
+
+import subprocess
+import sys
+import tomllib
+
+bump = sys.argv[1] if len(sys.argv) > 1 else "patch"
+if bump not in ("patch", "minor"):
+    print(f"Unknown bump type '{bump}'. Use 'patch' or 'minor'.")
+    sys.exit(1)
+
+with open("pyproject.toml", "rb") as f:
+    current = tomllib.load(f)["project"]["version"]
+
+parts = current.split(".")
+if bump == "minor":
+    parts[1] = str(int(parts[1]) + 1)
+    parts[2] = "0"
+else:
+    parts[2] = str(int(parts[2]) + 1)
+tag = ".".join(parts)
+
+print(f"Bumping {bump}: {current} -> {tag}")
+
+for path in ("pyproject.toml", "tests/test_cli.py"):
+    with open(path) as f:
+        content = f.read()
+    with open(path, "w") as f:
+        f.write(content.replace(current, tag))
+
+subprocess.run(["pip", "install", "-e", ".", "-q"], check=True)
+print("Done. Run 'tg --version' to verify.")


### PR DESCRIPTION
## Summary

- **Single-source versioning**: `pyproject.toml` is now the only place to bump the version. Both `__init__.py` and `cli.py` read it at runtime via `importlib.metadata` — no more hardcoded strings drifting out of sync
- **Removed unused dependencies**: `textual` and `quarto` were declared but never imported anywhere in `src/`. Runtime deps are now just `rich`, `pydantic`, `click`
- **`mise run testbump` task**: Bumps the patch or minor version in one command — updates `pyproject.toml`, syncs the `test_cli.py` version assertion, and reinstalls the package
  - `mise run testbump` → patch bump (e.g. `0.2.2` → `0.2.3`)
  - `mise run testbump minor` → minor bump (e.g. `0.2.2` → `0.3.0`)

## Test plan

- [ ] `tg --version` shows the version from `pyproject.toml`
- [ ] `mise run testbump` bumps patch and syncs test assertion
- [ ] `mise run testbump minor` bumps minor, resets patch to 0, syncs test assertion
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)