### PR TITLE
security: harden pre-release security posture

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+[allowlist]
+description = "Allowlist for known false positives"
+# Dummy SSH key strings written by test fixtures in test_config_manager.py — not real keys
+commits = ["92941014f7e86bb35a9c1694332ad4dd1c894c6f"]

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,0 +1,111 @@
+# Security Best Practices Report — tengingarstjori
+
+**Date:** 2026-04-11
+**Version:** 0.2.2
+**Language/Stack:** Python 3.10+, Click CLI, Pydantic, Rich
+
+---
+
+## Executive Summary
+
+The codebase demonstrates solid security fundamentals: file permissions are set atomically with `os.open()`, SSH config injection is mitigated via Pydantic validators, and subprocess calls use list form (no shell injection). Two findings warrant attention before a PyPI release, and several tooling gaps should be closed. No critical vulnerabilities were found.
+
+---
+
+## Findings by Severity
+
+### MEDIUM
+
+#### M-01 — `ProxyCommand` via `extra_options` can execute arbitrary shell commands
+
+**File:** `src/tengingarstjori/models.py:56–69`, `src/tengingarstjori/models.py:337–338`
+**Impact:** If a user (or a tampered `connections.json`) sets `extra_options: {ProxyCommand: "/bin/bash -c ..."}`, SSH will execute that shell command every time the host is connected to via `tg connect`. Newline injection is blocked, but the SSH `ProxyCommand` directive accepts arbitrary commands on a single line.
+
+The `extra_options` dict is written verbatim to the SSH config block:
+```python
+# models.py:337-338
+for key, value in self.extra_options.items():
+    lines.append(f"    {key} {value}")
+```
+
+**Recommendation:** Add a denylist (or allowlist) for dangerous SSH directives in `validate_extra_options`. At minimum, reject `ProxyCommand`, `LocalCommand`, `Match exec`, and `PermitLocalCommand`.
+
+---
+
+### LOW
+
+#### L-01 — `StrictHostKeyChecking=no` in health check disables MITM protection
+
+**File:** `src/tengingarstjori/cli.py:1828`
+
+```python
+"-o", "StrictHostKeyChecking=no",
+```
+
+This flag is passed unconditionally during `tg health`. It silently accepts any host key, defeating SSH's MITM protection for that check.
+
+**Recommendation:** Remove this flag or make it opt-in (`--insecure`). The default should be `StrictHostKeyChecking=accept-new` at most, or omit the option entirely to respect the user's SSH config.
+
+---
+
+#### L-02 — Main SSH config rewrite uses `open()` instead of `os.open()` with mode
+
+**File:** `src/tengingarstjori/config_manager.py:126`
+
+```python
+with open(self.main_ssh_config, "w") as f:
+    f.write(new_content)
+```
+
+All other sensitive file writes use `os.open(..., 0o600)`, but `_ensure_include_line()` rewrites `~/.ssh/config` with plain `open()`. On existing files this preserves permissions, but if the file was somehow removed between the existence check (line 118) and this write, it would be created with the process umask instead of `0o600`.
+
+**Recommendation:** Use the same `os.open` + `os.fdopen` pattern used in `_save_connections()` and `_update_ssh_config()`.
+
+---
+
+### INFORMATIONAL
+
+#### I-01 — No dependency vulnerability scanning in the lint/CI pipeline
+
+`bandit` is listed as an optional dev dependency and called in `mise run lint`, but there is no tool scanning the dependency graph for known CVEs. `rich`, `pydantic`, and `click` are low-risk but any PyPI release should have an automated check.
+
+**Recommendation:** Add `pip-audit` to the `lint` or `dev` optional-dependencies group and to `mise run lint`.
+
+#### I-02 — No secret/credential scanning before publish
+
+No tool checks for accidentally committed secrets (API keys, tokens) in the git history or staged files before a PyPI push.
+
+**Recommendation:** Add `gitleaks` or `trufflehog` as a pre-publish step.
+
+#### I-03 — `bandit` not pinned as a hard dev dependency
+
+`bandit` is referenced in `mise run lint` but is not in `pyproject.toml`'s `dev` or `lint` extras, making it optional and easy to skip.
+
+**Recommendation:** Add `bandit>=1.7.0` to the `lint` extras in `pyproject.toml`.
+
+---
+
+## Recommended Local Tools to Add
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| `pip-audit` | Scans installed deps for CVEs (PyPA official) | `pip install pip-audit` |
+| `bandit` | SAST for Python (already used, needs pinning) | `pip install bandit` |
+| `gitleaks` | Secret scanning in git history/staged files | `brew install gitleaks` |
+| `semgrep` | Deep SAST with community Python rules | `pip install semgrep` |
+| `ruff` | Fast linter (superset of flake8, has security rules) | `pip install ruff` |
+
+For a PyPI release, **`pip-audit`** and **`gitleaks`** are the highest-value additions — they catch things `bandit` does not (supply-chain CVEs and credential leaks).
+
+---
+
+## Summary Table
+
+| ID | Severity | File | Description |
+|----|----------|------|-------------|
+| M-01 | Medium | models.py:56-69, 337-338 | `ProxyCommand` allowed via `extra_options` |
+| L-01 | Low | cli.py:1828 | `StrictHostKeyChecking=no` unconditional |
+| L-02 | Low | config_manager.py:126 | SSH config rewrite uses bare `open()` |
+| I-01 | Info | pyproject.toml | No CVE scanning for dependencies |
+| I-02 | Info | — | No secret scanning pre-publish |
+| I-03 | Info | pyproject.toml | `bandit` not in hard dev deps |

--- a/src/tengingarstjori/cli.py
+++ b/src/tengingarstjori/cli.py
@@ -1824,8 +1824,6 @@ def test(connection_ref: Optional[str], test_all: bool, timeout: int) -> None:
                     f"ConnectTimeout={timeout}",
                     "-o",
                     "BatchMode=yes",
-                    "-o",
-                    "StrictHostKeyChecking=no",
                     conn.name,
                     "exit",
                 ],

--- a/src/tengingarstjori/config_manager.py
+++ b/src/tengingarstjori/config_manager.py
@@ -123,7 +123,10 @@ class SSHConfigManager:
         # Add include line at the top
         new_content = f"{include_line}\n\n{existing_content.strip()}\n"
 
-        with open(self.main_ssh_config, "w") as f:
+        # Use os.open with explicit mode so the file is always created 0o600
+        # if it doesn't exist, matching the permission used for other sensitive files.
+        fd = os.open(self.main_ssh_config, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
             f.write(new_content)
 
         print(f"Added include line to {self.main_ssh_config}")

--- a/src/tengingarstjori/models.py
+++ b/src/tengingarstjori/models.py
@@ -6,6 +6,17 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
+# SSH directives that execute shell commands — never allow in extra_options.
+# ProxyCommand/LocalCommand run arbitrary shell code when SSH connects to a host.
+_DANGEROUS_SSH_OPTIONS: frozenset[str] = frozenset(
+    {
+        "proxycommand",
+        "localcommand",
+        "permitlocalcommand",
+        "match",
+    }
+)
+
 
 class SSHConnection(BaseModel):
     """Represents an SSH connection configuration."""
@@ -56,7 +67,11 @@ class SSHConnection(BaseModel):
     @field_validator("extra_options")
     @classmethod
     def validate_extra_options(cls, v: dict[str, str]) -> dict[str, str]:
-        """Reject extra_options keys/values containing newlines."""
+        """Reject extra_options keys/values containing newlines or dangerous directives.
+
+        ProxyCommand, LocalCommand, and similar directives execute shell commands
+        when SSH connects — they must not be user-controllable via extra_options.
+        """
         for key, value in v.items():
             if "\n" in key or "\r" in key:
                 raise ValueError(
@@ -65,6 +80,11 @@ class SSHConnection(BaseModel):
             if "\n" in value or "\r" in value:
                 raise ValueError(
                     f"extra_options value must not contain newlines: {value!r}"
+                )
+            if key.lower() in _DANGEROUS_SSH_OPTIONS:
+                raise ValueError(
+                    f"extra_options key '{key}' is not allowed: this directive can "
+                    f"execute arbitrary shell commands. Use ProxyJump instead."
                 )
         return v
 


### PR DESCRIPTION
## Changes

- **Added security audit report** (`security_best_practices_report.md`): Documents findings from security review, including 1 medium and 2 low severity issues, with recommendations before PyPI release.

- **Added gitleaks config** (`.gitleaks.toml`): Configured secret scanning with allowlist for known false positives in test fixtures.

- **Fixed ProxyCommand injection vulnerability** (`models.py`): Added denylist of dangerous SSH directives (`ProxyCommand`, `LocalCommand`, `PermitLocalCommand`, `Match`) to `validate_extra_options()` to prevent arbitrary shell execution via `extra_options` dict.

- **Removed insecure StrictHostKeyChecking flag** (`cli.py`): Removed unconditional `StrictHostKeyChecking=no` from health check that bypassed MITM protection.

- **Fixed SSH config file permissions** (`config_manager.py`): Changed `_ensure_include_line()` to use `os.open()` with explicit `0o600` mode for atomic secure file creation, matching existing sensitive file write patterns.

## Impact

- **Medium**: ProxyCommand injection now blocked at validation layer
- **Low**: SSH health checks now respect system host key policies
- **Low**: SSH config creation now guarantees `0o600` permissions atomically